### PR TITLE
Fix bug where query is not created correctly when there only hidden args exists

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -574,7 +574,9 @@ func (st *driverStmt) QueryContext(ctx context.Context, args []driver.NamedValue
 				ss = append(ss, s)
 			}
 		}
-		query = "EXECUTE " + preparedStatementName + " USING " + strings.Join(ss, ", ")
+		if len(ss) > 0 {
+			query = "EXECUTE " + preparedStatementName + " USING " + strings.Join(ss, ", ")
+		}
 	}
 
 	req, err := st.conn.newRequest("POST", st.conn.baseURL+"/v1/statement", strings.NewReader(query), hs)


### PR DESCRIPTION
Issue related to #3 

Query is not created correctly if the arg provided to QueryContext function is hidden arg (PrestoUserHeader) 

Fixes #3