### PR TITLE
Fix serializing user name

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -565,7 +565,7 @@ func (st *driverStmt) QueryContext(ctx context.Context, args []driver.NamedValue
 				return nil, err
 			}
 			if arg.Name == prestoUserHeader {
-				st.user = s
+				st.user = arg.Value.(string)
 				hs.Add(prestoUserHeader, st.user)
 			} else {
 				if hs.Get(preparedStatementHeader) == "" {

--- a/presto/presto_test.go
+++ b/presto/presto_test.go
@@ -203,7 +203,7 @@ func TestAuthFailure(t *testing.T) {
 	defer db.Close()
 }
 
-func TestQueryWithJustUserHeader(t *testing.T) {
+func TestQueryForUsername(t *testing.T) {
 	c := &Config{
 		PrestoURI:         "http://foobar@localhost:8080",
 		SessionProperties: map[string]string{"query_priority": "1"},
@@ -218,7 +218,7 @@ func TestQueryWithJustUserHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	rows, err := db.Query("SELECT 2", sql.Named("X-Presto-User", string("TestUser")))
+	rows, err := db.Query("SELECT current_user", sql.Named("X-Presto-User", string("TestUser")))
 	if err != nil {
 		t.Fatal("Failed executing query", err.Error())
 	}
@@ -230,7 +230,7 @@ func TestQueryWithJustUserHeader(t *testing.T) {
 			if err != nil {
 				t.Fatal("Failed scanning query result", err.Error())
 			}
-			want := "2"
+			want := "TestUser"
 			if ts != want {
 				t.Fatal("Expected value does not equal result value : ", ts, " != ", want)
 			}


### PR DESCRIPTION
Issue related to https://github.com/prestosql/presto-go-client/issues/6 where hidden args should not be serialized. 

### before
![image](https://user-images.githubusercontent.com/25147023/89846403-1c19aa00-dbbc-11ea-8edb-242fd399372e.png)


### after

![image](https://user-images.githubusercontent.com/25147023/89846410-2045c780-dbbc-11ea-90ac-1995aa694150.png)

Fixes #6 